### PR TITLE
Errors

### DIFF
--- a/streamer/src/services/blocks/blocks.ts
+++ b/streamer/src/services/blocks/blocks.ts
@@ -104,15 +104,6 @@ class BlocksService implements IBlocksService {
     counter.inc(1)
   }
 
-  /**
-   * Process all blocks with head
-   *
-   * @public
-   * @async
-   * @param startBlockNumber
-   * @param optionSubscribeFinHead
-   * @returns {Promise<void>}
-   */
   async processBlocks(startBlockNumber: number | null = null, optionSubscribeFinHead: boolean | null = null): Promise<void> {
     BlocksService.status = SyncStatus.SYNC
 
@@ -143,7 +134,7 @@ class BlocksService implements IBlocksService {
 
     BlocksService.status = SyncStatus.SUBSCRIPTION
 
-    if (optionSubscribeFinHead) this.consumerService.subscribeFinalizedHeads()
+    if (optionSubscribeFinHead) return this.consumerService.subscribeFinalizedHeads()
   }
 
   /**

--- a/streamer/src/services/consumer/consumer.ts
+++ b/streamer/src/services/consumer/consumer.ts
@@ -13,15 +13,19 @@ class ConsumerService implements IConsumerService {
   private readonly logger: ILoggerModule = LoggerModule.inject()
 
   async subscribeFinalizedHeads(): Promise<void> {
-    if (!BlocksService.isSyncComplete()) {
-      this.logger.error(`failed setup "subscribeFinalizedHeads": sync in process`)
-      return
-    }
+    return new Promise((resolve, reject) => {
+      if (!BlocksService.isSyncComplete()) {
+        throw new Error(`failed setup "subscribeFinalizedHeads": sync is not completed`)
+      }
 
-    this.logger.info(`Starting subscribeFinalizedHeads`)
+      this.logger.info(`Starting subscribeFinalizedHeads`)
 
-    await this.polkadotApi.subscribeFinalizedHeads((header) => {
-      return this.onFinalizedHead(header)
+      this.polkadotApi.subscribeFinalizedHeads((header) => {
+        return this.onFinalizedHead(header).catch((error) => {
+          console.log(error)
+          reject(error)
+        })
+      })
     })
   }
 

--- a/streamer/src/services/consumer/consumer.ts
+++ b/streamer/src/services/consumer/consumer.ts
@@ -7,20 +7,11 @@ import { PolkadotModule } from '../../modules/polkadot.module'
 import { ILoggerModule, LoggerModule } from '../../modules/logger.module'
 import { BlockRepository } from '../../repositories/block.repository'
 
-/**
- * Provides blocks streamer service
- * @class
- */
 class ConsumerService implements IConsumerService {
   private readonly blockRepository: BlockRepository = BlockRepository.inject()
   private readonly polkadotApi: PolkadotModule = PolkadotModule.inject()
   private readonly logger: ILoggerModule = LoggerModule.inject()
-  /**
-   * Subscribe to finalized heads stream
-   *
-   * @async
-   * @returns {Promise<void>}
-   */
+
   async subscribeFinalizedHeads(): Promise<void> {
     if (!BlocksService.isSyncComplete()) {
       this.logger.error(`failed setup "subscribeFinalizedHeads": sync in process`)
@@ -29,25 +20,11 @@ class ConsumerService implements IConsumerService {
 
     this.logger.info(`Starting subscribeFinalizedHeads`)
 
-    const blockNumberFromDB = await this.blockRepository.getLastProcessedBlock()
-
-    if (blockNumberFromDB === 0) {
-      this.logger.warn(`"subscribeFinalizedHeads" capture enabled but, not synchronized blocks `)
-    }
-
     await this.polkadotApi.subscribeFinalizedHeads((header) => {
       return this.onFinalizedHead(header)
     })
   }
 
-  /**
-   * Finalized headers capture handler
-   *
-   * @async
-   * @private
-   * @param {BlockHash} blockHash
-   * @returns {Promise<void>}
-   */
   private async onFinalizedHead(blockHash: Header): Promise<void> {
     const blocksService: IBlocksService = new BlocksService()
 


### PR DESCRIPTION
Added catch for errors during fin blocks subscription, to exit app in case of api version mismatch. 
To avoid it, should watch for nodes runtime updates, then "npm update" and restart streamers and enrichments_processors.