### PR TITLE
init prometheus counter to current processed block id

### DIFF
--- a/streamer/src/services/blocks/blocks.ts
+++ b/streamer/src/services/blocks/blocks.ts
@@ -125,6 +125,8 @@ class BlocksService implements IBlocksService {
 
     let blockNumber: number = startBlockNumber
 
+    counter.inc(blockNumber)
+
     while (blockNumber <= lastBlockNumber) {
       const chunk = 10
       const processTasks = Array(chunk)
@@ -143,22 +145,6 @@ class BlocksService implements IBlocksService {
     if (optionSubscribeFinHead) return this.consumerService.subscribeFinalizedHeads()
   }
 
-  /**
-   * Synchronization status
-   *
-   * @typedef {Object} SyncSimpleStatus
-   * @property {string} status
-   * @property {number} fin_height_diff
-   * @property {number} height_diff
-   */
-
-  /**
-   *  Returns synchronization status, and diff between head and finalized head
-   *
-   * @public
-   * @async
-   * @returns {Promise<SyncSimpleStatus>}
-   */
   async getBlocksStatus(): Promise<IBlocksStatusResult> {
     const result = {
       status: 'undefined',

--- a/streamer/src/services/statcollector/statcollector.ts
+++ b/streamer/src/services/statcollector/statcollector.ts
@@ -1,7 +1,7 @@
 import pc from 'prom-client'
 
 export const counter = new pc.Counter({
-	name: 'blocks_service',
-	labelNames: ['processBlocks', 'getLastProcessedBlock', 'getBlocksStatus'],
-	help: 'blocks_service_desc'
+  name: 'blocks_service',
+  labelNames: ['processBlocks', 'getLastProcessedBlock', 'getBlocksStatus'],
+  help: 'blocks_service_desc'
 })


### PR DESCRIPTION
prom-client metric "counter" initialized to the current processed block id on startup