### PR TITLE
Fix the jq command to add a default '.'

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -148,7 +148,7 @@ for file in "$DIR_KSQL_INIT_CONFIG"/*.sql; do
     GEN_KSQL=${GEN_KSQL//\{$param\}/${!param}}
   done
 
-  GEN_KSQL=$(echo "$GEN_KSQL" | jq -Rs)
+  GEN_KSQL=$(echo "$GEN_KSQL" | jq -Rs .)
   KSQL_INIT="${KSQL_FILE_TEMPLATE//\{KSQL\}/$GEN_KSQL}"
 
   KSQL_RESP_MESSAGE=$(curl -sX "POST" "$KAFKA_KSQL_DB_URL/ksql" \


### PR DESCRIPTION
Needed for earlier jq versions <1.6 that come pre-installed with Ubuntu bionic 18.04. Dot (`.`) is the identity operator for `jq` so doesn't affect the output on newer versions.